### PR TITLE
Fix naming related warnings

### DIFF
--- a/bs_bin/src/handler.rs
+++ b/bs_bin/src/handler.rs
@@ -10,7 +10,7 @@ use std::io;
 use std::io::Read;
 use std::io::Write;
 
-use crate::repl::Repl;
+use crate::repl::repl;
 
 pub fn handle() {
     let matches = App::new("Brainsuck")
@@ -50,7 +50,7 @@ pub fn handle() {
     if matches.value_of("INPUT") == None {
         print!("\n{}\n-------------------------------------\nType \"{}\" or press CTRL + C to exit\n-------------------------------------\n\n", "Brainsuck Interactive Shell".bright_green(), "quit".bright_magenta());
 
-        Repl();
+        repl();
     } else {
         let mut file = File::open(matches.value_of("INPUT").unwrap()).map_err(|err| {
             BrainsuckError::throw_error(
@@ -76,8 +76,8 @@ pub fn handle() {
             )
         });
 
-        let ops = bs_lib::lexer::Lex(src);
-        let program = bs_lib::parser::Parse(ops, false);
+        let ops = bs_lib::lexer::lex(src);
+        let program = bs_lib::parser::parse(ops, false);
 
         let mem_str = matches.value_of("mem-size").unwrap_or("1024");
         let mem_size = mem_str.parse::<usize>().unwrap();
@@ -97,7 +97,7 @@ pub fn handle() {
         let mut memory: Vec<u8> = vec![0; mem_size];
         let mut memory_pointer: usize = ptr_loc;
 
-        bs_lib::interpreter::Interpret(
+        bs_lib::interpreter::interpret(
             &program,
             &mut memory,
             &mut memory_pointer,

--- a/bs_bin/src/repl.rs
+++ b/bs_bin/src/repl.rs
@@ -1,7 +1,7 @@
 use bs_lib::{
-    interpreter::Interpret,
-    lexer::Lex,
-    parser::Parse,
+    interpreter::interpret,
+    lexer::lex,
+    parser::parse,
     utils::{BrainsuckMessage, BrainsuckMessageType},
 };
 
@@ -11,7 +11,7 @@ use std::io::{BufRead, BufReader, Write};
 
 use std::{io, process::exit};
 
-pub fn Repl() {
+pub fn repl() {
     loop {
         let input = get_input(">>> ").unwrap();
 
@@ -28,8 +28,8 @@ pub fn Repl() {
         let mut memory: Vec<u8> = vec![0; 1024];
         let mut memory_pointer: usize = 512;
 
-        Interpret(
-            &Parse(Lex(input), true),
+        interpret(
+            &parse(lex(input), true),
             &mut memory,
             &mut memory_pointer,
             true,

--- a/bs_lib/src/interpreter.rs
+++ b/bs_lib/src/interpreter.rs
@@ -3,7 +3,7 @@ use crate::utils::{BrainsuckError, BrainsuckErrorType};
 
 use std::io::{self, Read};
 
-pub fn Interpret(
+pub fn interpret(
     instructions: &Vec<Instruction>,
     memory: &mut Vec<u8>,
     memory_pointer: &mut usize,
@@ -25,7 +25,7 @@ pub fn Interpret(
 
         match inst {
             Instruction::IncrementPointer => match memory.get(*memory_pointer + 1) {
-                Some(v) => *memory_pointer += 1,
+                Some(_v) => *memory_pointer += 1,
                 None => BrainsuckError::throw_error(
                     "Memory overflow!\nHelp: Give program more memory.".to_owned(),
                     BrainsuckErrorType::MemoryError,
@@ -33,7 +33,7 @@ pub fn Interpret(
                 ),
             },
             Instruction::DecrementPointer => match memory.get(*memory_pointer - 1) {
-                Some(v) => *memory_pointer -= 1,
+                Some(_v) => *memory_pointer -= 1,
                 None => BrainsuckError::throw_error(
                     "Memory overflow!\nHelp: Give program more memory.".to_owned(),
                     BrainsuckErrorType::MemoryError,
@@ -41,7 +41,7 @@ pub fn Interpret(
                 ),
             },
             Instruction::Increment => match memory.get(*memory_pointer - 1) {
-                Some(v) => memory[*memory_pointer] += 1,
+                Some(_v) => memory[*memory_pointer] += 1,
                 None => BrainsuckError::throw_error(
                     "Memory overflow!\nHelp: Give program more memory.".to_owned(),
                     BrainsuckErrorType::MemoryError,
@@ -49,7 +49,7 @@ pub fn Interpret(
                 ),
             },
             Instruction::Decrement => match memory.get(*memory_pointer - 1) {
-                Some(v) => memory[*memory_pointer] -= 1,
+                Some(_v) => memory[*memory_pointer] -= 1,
                 None => BrainsuckError::throw_error(
                     "Memory overflow!\nHelp: Give program more memory.".to_owned(),
                     BrainsuckErrorType::MemoryError,
@@ -68,7 +68,7 @@ pub fn Interpret(
 
                 match io::stdin().read_exact(&mut input_byte) {
                     Ok(()) => (),
-                    Err(e) => BrainsuckError::throw_error(
+                    Err(_e) => BrainsuckError::throw_error(
                         "Can't read input form stdin".to_owned(),
                         BrainsuckErrorType::IOError,
                         repl_mode,
@@ -79,7 +79,7 @@ pub fn Interpret(
             }
             Instruction::Loop(loop_instructions) => {
                 while memory[*memory_pointer] != 0 {
-                    Interpret(&loop_instructions, memory, memory_pointer, true, false)
+                    interpret(&loop_instructions, memory, memory_pointer, true, false)
                 }
             }
         }

--- a/bs_lib/src/lexer.rs
+++ b/bs_lib/src/lexer.rs
@@ -8,7 +8,7 @@ use crate::types::OpCode;
     to a Vector of OpCodes.
 */
 
-pub fn Lex(source: String) -> Vec<OpCode> {
+pub fn lex(source: String) -> Vec<OpCode> {
     let mut operations: Vec<OpCode> = Vec::new();
 
     let chars: Vec<char> = source.chars().collect();

--- a/bs_lib/src/parser.rs
+++ b/bs_lib/src/parser.rs
@@ -11,7 +11,7 @@ use crate::utils::{BrainsuckError, BrainsuckErrorType};
     by the interpreter
 */
 
-pub fn Parse(opcodes: Vec<OpCode>, repl_mode: bool) -> Vec<Instruction> {
+pub fn parse(opcodes: Vec<OpCode>, repl_mode: bool) -> Vec<Instruction> {
     let mut program: Vec<Instruction> = Vec::new();
     let mut loop_start: usize = 0;
     let mut loop_stack: i32 = 0;
@@ -55,7 +55,7 @@ pub fn Parse(opcodes: Vec<OpCode>, repl_mode: bool) -> Vec<Instruction> {
                     loop_stack -= 1;
 
                     if loop_stack == 0 {
-                        program.push(Instruction::Loop(Parse(
+                        program.push(Instruction::Loop(parse(
                             opcodes[loop_start + 1..i].to_vec(),
                             repl_mode,
                         )));

--- a/bs_lib/src/utils.rs
+++ b/bs_lib/src/utils.rs
@@ -4,8 +4,8 @@ use std::io::Write;
 use std::process::exit;
 
 pub struct BrainsuckError {
-    Message: String,
-    ErrorType: BrainsuckErrorType,
+    message: String,
+    error_type: BrainsuckErrorType,
 }
 
 pub enum BrainsuckErrorType {
@@ -20,13 +20,13 @@ pub enum BrainsuckErrorType {
 impl BrainsuckError {
     pub fn new(message: String, error_type: BrainsuckErrorType) -> BrainsuckError {
         return BrainsuckError {
-            Message: message,
-            ErrorType: error_type,
+            message,
+            error_type,
         };
     }
 
     pub fn display(&self) {
-        let err_type: String = match &self.ErrorType {
+        let err_type: String = match &self.error_type {
             BrainsuckErrorType::FileNotFoundError => String::from("File Not Found"),
             BrainsuckErrorType::CantReadFileError => String::from("Cant Read File"),
             BrainsuckErrorType::SyntaxError => String::from("Syntax Error"),
@@ -38,7 +38,7 @@ impl BrainsuckError {
             "\n{}\n---------\nError [{}]\n\nMessage: {}\n\n",
             "Brainsuck".bright_green(),
             err_type.bright_cyan(),
-            &self.Message.bright_yellow()
+            &self.message.bright_yellow()
         )
         .bright_red();
         io::stdout().lock().write(short_msg.as_bytes()).unwrap();
@@ -54,8 +54,8 @@ impl BrainsuckError {
 }
 
 pub struct BrainsuckMessage {
-    Message: String,
-    MessageType: BrainsuckMessageType,
+    message: String,
+    message_type: BrainsuckMessageType,
 }
 
 pub enum BrainsuckMessageType {
@@ -65,13 +65,13 @@ pub enum BrainsuckMessageType {
 impl BrainsuckMessage {
     pub fn new(message: String, message_type: BrainsuckMessageType) -> BrainsuckMessage {
         return BrainsuckMessage {
-            Message: message,
-            MessageType: message_type,
+            message,
+            message_type,
         };
     }
 
     pub fn display(&self) {
-        let message_type: String = match &self.MessageType {
+        let message_type: String = match &self.message_type {
             BrainsuckMessageType::Notification => String::from("Notification"),
         };
 
@@ -79,7 +79,7 @@ impl BrainsuckMessage {
             "\n{}\n---------\nType: [{}]\n\nMessage: {}\n\n",
             "Brainsuck".bright_green(),
             message_type.bright_cyan(),
-            &self.Message.bright_yellow()
+            &self.message.bright_yellow()
         )
         .bright_red();
         io::stdout().lock().write(short_msg.as_bytes()).unwrap();


### PR DESCRIPTION
Variables and functions should use snake_case and unused variables
should be prefixed wih an underscore. This is the standard naming
convention in Rust and is enforced through compiler warnings.