### PR TITLE
Fix the rest of the warnings

### DIFF
--- a/bs_bin/src/handler.rs
+++ b/bs_bin/src/handler.rs
@@ -2,13 +2,10 @@ extern crate clap;
 use clap::{App, Arg};
 use colored::Colorize;
 
-use bs_lib;
 use bs_lib::utils::{BrainsuckError, BrainsuckErrorType, BrainsuckMessage, BrainsuckMessageType};
 
 use std::fs::File;
-use std::io;
 use std::io::Read;
-use std::io::Write;
 
 use crate::repl::repl;
 
@@ -52,7 +49,7 @@ pub fn handle() {
 
         repl();
     } else {
-        let mut file = File::open(matches.value_of("INPUT").unwrap()).map_err(|err| {
+        let file = File::open(matches.value_of("INPUT").unwrap()).map_err(|_err| {
             BrainsuckError::throw_error(
                 format!(
                     "Can't find input file '{}'",
@@ -65,16 +62,19 @@ pub fn handle() {
 
         let mut src = String::new();
 
-        file.unwrap().read_to_string(&mut src).map_err(|err| {
-            BrainsuckError::throw_error(
-                format!(
-                    "Can't read the input file '{}'",
-                    matches.value_of("INPUT").unwrap()
-                ),
-                BrainsuckErrorType::CantReadFileError,
-                true,
-            )
-        });
+        file.unwrap()
+            .read_to_string(&mut src)
+            .map_err(|_err| {
+                BrainsuckError::throw_error(
+                    format!(
+                        "Can't read the input file '{}'",
+                        matches.value_of("INPUT").unwrap()
+                    ),
+                    BrainsuckErrorType::CantReadFileError,
+                    true,
+                )
+            })
+            .unwrap();
 
         let ops = bs_lib::lexer::lex(src);
         let program = bs_lib::parser::parse(ops, false);

--- a/bs_bin/src/handler.rs
+++ b/bs_bin/src/handler.rs
@@ -77,7 +77,7 @@ pub fn handle() {
             .unwrap();
 
         let ops = bs_lib::lexer::lex(src);
-        let program = bs_lib::parser::parse(ops, false);
+        let program = bs_lib::parser::parse(&ops, false);
 
         let mem_str = matches.value_of("mem-size").unwrap_or("1024");
         let mem_size = mem_str.parse::<usize>().unwrap();

--- a/bs_bin/src/repl.rs
+++ b/bs_bin/src/repl.rs
@@ -24,7 +24,7 @@ pub fn repl() {
         let mut memory_pointer: usize = 512;
 
         interpret(
-            &parse(lex(input), true),
+            &parse(&lex(input), true),
             &mut memory,
             &mut memory_pointer,
             true,

--- a/bs_bin/src/repl.rs
+++ b/bs_bin/src/repl.rs
@@ -1,9 +1,4 @@
-use bs_lib::{
-    interpreter::interpret,
-    lexer::lex,
-    parser::parse,
-    utils::{BrainsuckMessage, BrainsuckMessageType},
-};
+use bs_lib::{interpreter::interpret, lexer::lex, parser::parse};
 
 use colored::Colorize;
 

--- a/bs_lib/src/interpreter.rs
+++ b/bs_lib/src/interpreter.rs
@@ -4,7 +4,7 @@ use crate::utils::{BrainsuckError, BrainsuckErrorType};
 use std::io::{self, Read};
 
 pub fn interpret(
-    instructions: &Vec<Instruction>,
+    instructions: &[Instruction],
     memory: &mut Vec<u8>,
     memory_pointer: &mut usize,
     auto_alloc: bool,
@@ -79,7 +79,7 @@ pub fn interpret(
             }
             Instruction::Loop(loop_instructions) => {
                 while memory[*memory_pointer] != 0 {
-                    interpret(&loop_instructions, memory, memory_pointer, true, false)
+                    interpret(loop_instructions, memory, memory_pointer, true, false)
                 }
             }
         }

--- a/bs_lib/src/lexer.rs
+++ b/bs_lib/src/lexer.rs
@@ -27,13 +27,12 @@ pub fn lex(source: String) -> Vec<OpCode> {
             _ => None,
         };
 
-        match op {
-            Some(op) => operations.push(op),
-            None => (),
+        if let Some(op) = op {
+            operations.push(op);
         }
 
-        current_char = current_char + 1;
+        current_char += 1;
     }
 
-    return operations;
+    operations
 }

--- a/bs_lib/src/parser.rs
+++ b/bs_lib/src/parser.rs
@@ -42,11 +42,8 @@ pub fn parse(opcodes: Vec<OpCode>, repl_mode: bool) -> Vec<Instruction> {
                 }
             };
 
-            match inst {
-                Some(inst) => {
-                    program.push(inst);
-                }
-                None => (),
+            if let Some(inst) = inst {
+                program.push(inst);
             }
         } else {
             match op {
@@ -75,5 +72,5 @@ pub fn parse(opcodes: Vec<OpCode>, repl_mode: bool) -> Vec<Instruction> {
         );
     }
 
-    return program;
+    program
 }

--- a/bs_lib/src/parser.rs
+++ b/bs_lib/src/parser.rs
@@ -11,7 +11,7 @@ use crate::utils::{BrainsuckError, BrainsuckErrorType};
     by the interpreter
 */
 
-pub fn parse(opcodes: Vec<OpCode>, repl_mode: bool) -> Vec<Instruction> {
+pub fn parse(opcodes: &[OpCode], repl_mode: bool) -> Vec<Instruction> {
     let mut program: Vec<Instruction> = Vec::new();
     let mut loop_start: usize = 0;
     let mut loop_stack: i32 = 0;
@@ -53,7 +53,7 @@ pub fn parse(opcodes: Vec<OpCode>, repl_mode: bool) -> Vec<Instruction> {
 
                     if loop_stack == 0 {
                         program.push(Instruction::Loop(parse(
-                            opcodes[loop_start + 1..i].to_vec(),
+                            &opcodes[loop_start + 1..i],
                             repl_mode,
                         )));
                     }

--- a/bs_lib/src/utils.rs
+++ b/bs_lib/src/utils.rs
@@ -1,4 +1,4 @@
-use colored::{Color, Colorize};
+use colored::Colorize;
 use std::io;
 use std::io::Write;
 use std::process::exit;
@@ -19,10 +19,10 @@ pub enum BrainsuckErrorType {
 
 impl BrainsuckError {
     pub fn new(message: String, error_type: BrainsuckErrorType) -> BrainsuckError {
-        return BrainsuckError {
+        BrainsuckError {
             message,
             error_type,
-        };
+        }
     }
 
     pub fn display(&self) {
@@ -41,7 +41,7 @@ impl BrainsuckError {
             &self.message.bright_yellow()
         )
         .bright_red();
-        io::stdout().lock().write(short_msg.as_bytes()).unwrap();
+        io::stdout().lock().write_all(short_msg.as_bytes()).unwrap();
     }
 
     pub fn throw_error(message: String, err_type: BrainsuckErrorType, do_exit: bool) {
@@ -64,10 +64,10 @@ pub enum BrainsuckMessageType {
 
 impl BrainsuckMessage {
     pub fn new(message: String, message_type: BrainsuckMessageType) -> BrainsuckMessage {
-        return BrainsuckMessage {
+        BrainsuckMessage {
             message,
             message_type,
-        };
+        }
     }
 
     pub fn display(&self) {
@@ -82,7 +82,7 @@ impl BrainsuckMessage {
             &self.message.bright_yellow()
         )
         .bright_red();
-        io::stdout().lock().write(short_msg.as_bytes()).unwrap();
+        io::stdout().lock().write_all(short_msg.as_bytes()).unwrap();
     }
 
     pub fn throw_message(message: String, message_type: BrainsuckMessageType) {


### PR DESCRIPTION
This patch fixes all warnings, both from the compiler and from Clippy.
It's always a good idea to check your code with Clippy before commiting
it. This can be done by running `cargo clippy` in the `bs_lib` and
`bs_bin` directories.