### PR TITLE
Simplify the lexer

### DIFF
--- a/bs_bin/src/handler.rs
+++ b/bs_bin/src/handler.rs
@@ -76,7 +76,7 @@ pub fn handle() {
             })
             .unwrap();
 
-        let ops = bs_lib::lexer::lex(src);
+        let ops = bs_lib::lexer::lex(&src);
         let program = bs_lib::parser::parse(&ops, false);
 
         let mem_str = matches.value_of("mem-size").unwrap_or("1024");

--- a/bs_bin/src/repl.rs
+++ b/bs_bin/src/repl.rs
@@ -24,7 +24,7 @@ pub fn repl() {
         let mut memory_pointer: usize = 512;
 
         interpret(
-            &parse(&lex(input), true),
+            &parse(&lex(&input), true),
             &mut memory,
             &mut memory_pointer,
             true,

--- a/bs_lib/src/lexer.rs
+++ b/bs_lib/src/lexer.rs
@@ -8,14 +8,11 @@ use crate::types::OpCode;
     to a Vector of OpCodes.
 */
 
-pub fn lex(source: String) -> Vec<OpCode> {
+pub fn lex(source: &str) -> Vec<OpCode> {
     let mut operations: Vec<OpCode> = Vec::new();
 
-    let chars: Vec<char> = source.chars().collect();
-    let mut current_char: usize = 0;
-
-    while current_char < chars.len() {
-        let op = match chars[current_char] {
+    for current_char in source.chars() {
+        let op = match current_char {
             '>' => Some(OpCode::IncrementPointer),
             '<' => Some(OpCode::DecrementPointer),
             '+' => Some(OpCode::Increment),
@@ -30,8 +27,6 @@ pub fn lex(source: String) -> Vec<OpCode> {
         if let Some(op) = op {
             operations.push(op);
         }
-
-        current_char += 1;
     }
 
     operations


### PR DESCRIPTION
This replaces the main loop of `lex()` with a for loop that iterates
over the characters of the input directly without collecting them. Since
this doesn't require ownership of the input, it can be passed as a
borrowed `str` instead of an owned `String`.